### PR TITLE
Validate member postal code against library-specified pattern

### DIFF
--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -1,2 +1,7 @@
 class Library < ApplicationRecord
+  def allows_postal_code?(postal_code)
+    return true if postal_code.blank?
+
+    /#{member_postal_code_pattern}/ =~ postal_code.to_s
+  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -97,10 +97,10 @@ class Member < ApplicationRecord
   end
 
   def postal_code_must_be_in_chicago
-    return true if postal_code.nil?
+    return unless library && postal_code.present?
 
-    unless ["60707", "60827"].include?(postal_code) || postal_code.starts_with?("606")
-      errors.add :postal_code, "must be in Chicago"
+    unless library.allows_postal_code?(postal_code)
+      errors.add :postal_code, "must be admissible in #{library.name}"
     end
   end
 end

--- a/db/migrate/20200924141025_add_member_postal_code_pattern_to_libraries.rb
+++ b/db/migrate/20200924141025_add_member_postal_code_pattern_to_libraries.rb
@@ -1,5 +1,14 @@
 class AddMemberPostalCodePatternToLibraries < ActiveRecord::Migration[6.0]
   def change
     add_column :libraries, :member_postal_code_pattern, :string, limit: 100, null: true, default: nil
+
+    library_zero_id = select_value("SELECT id FROM libraries WHERE hostname = 'chicagotoollibrary.herokuapp.com'").presence
+    return unless library_zero_id
+
+    reversible do |dir|
+      dir.up do
+        execute "UPDATE libraries SET member_postal_code_pattern = '60707|60827|^606' WHERE id = #{library_zero_id}"
+      end
+    end
   end
 end

--- a/db/migrate/20200924141025_add_member_postal_code_pattern_to_libraries.rb
+++ b/db/migrate/20200924141025_add_member_postal_code_pattern_to_libraries.rb
@@ -1,0 +1,5 @@
+class AddMemberPostalCodePatternToLibraries < ActiveRecord::Migration[6.0]
+  def change
+    add_column :libraries, :member_postal_code_pattern, :string, limit: 100, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_24_072906) do
+ActiveRecord::Schema.define(version: 2020_09_24_141025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -275,6 +275,7 @@ ActiveRecord::Schema.define(version: 2020_09_24_072906) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "hostname", null: false
+    t.string "member_postal_code_pattern", limit: 100
     t.index ["hostname"], name: "index_libraries_on_hostname", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,7 +35,7 @@ Document.create!(name: "Borrow Policy", code: "borrow_policy", summary: "Covers 
 Document.create!(name: "Chicago Tool Library Code of Conduct", code: "code_of_conduct", summary: "Defines acceptable behavior for CTL")
 
 ActsAsTenant.with_tenant(
-  Library.create!(name: "Chicago Tool Library", hostname: "chicago.local.chicagotoollibrary.org")
+  Library.create!(name: "Chicago Tool Library", hostname: "chicago.local.chicagotoollibrary.org", member_postal_code_pattern: "60707|60827|^606")
 ) do
   super_admin_member = Member.create!(
     email: "super_admin@chicagotoollibrary.org", full_name: "Super Admin Member", preferred_name: "Super Admin",
@@ -85,12 +85,12 @@ ActsAsTenant.with_tenant(
 end
 
 ActsAsTenant.with_tenant(
-  Library.create!(name: "North Portland Tool Library", hostname: "portland.local.chicagotoollibrary.org")
+  Library.create!(name: "North Portland Tool Library", hostname: "portland.local.chicagotoollibrary.org", member_postal_code_pattern: "97086|^972")
 ) do
   admin_member = Member.create!(
     email: "admin_portland@chicagotoollibrary.org", full_name: "Admin Member", preferred_name: "Admin",
     phone_number: "5035550209", pronouns: ["she/her"], id_kind: 0, address_verified: false, desires: "saws, hammers",
-    address1: "123 S. Streetname St.", address2: "Apt. 4", city: "Portland", region: "OR", postal_code: "60666",
+    address1: "123 S. Streetname St.", address2: "Apt. 4", city: "Portland", region: "OR", postal_code: "97266",
     reminders_via_email: true, reminders_via_text: true, receive_newsletter: true, volunteer_interest: true
   )
   User.create!(email: admin_member.email, password: "password", member: admin_member)
@@ -98,7 +98,7 @@ ActsAsTenant.with_tenant(
   verified_member = Member.create!(
     email: "verifiedmember_portland@example.com", full_name: "Firstname Lastname", preferred_name: "Verified", status: 1,
     phone_number: "5035550209", pronouns: ["she/her"], id_kind: 0, address_verified: true, desires: "saws, hammers",
-    address1: "123 S. Streetname St.", address2: "Apt. 4", city: "Portland", region: "OR", postal_code: "60666",
+    address1: "123 S. Streetname St.", address2: "Apt. 4", city: "Portland", region: "OR", postal_code: "97086",
     reminders_via_email: true, reminders_via_text: true, receive_newsletter: true, volunteer_interest: true
   )
   User.create!(email: verified_member.email, password: "password", member: verified_member)
@@ -107,7 +107,7 @@ ActsAsTenant.with_tenant(
   unverified_member = Member.create!(
     email: "newmember_portland@example.com", full_name: "Firstname Lastname", preferred_name: "New",
     phone_number: "5035550209", pronouns: ["she/her"], id_kind: 0, address_verified: false, desires: "saws, hammers",
-    address1: "123 S. Streetname St.", address2: "Apt. 4", city: "Portland", region: "OR", postal_code: "60666",
+    address1: "123 S. Streetname St.", address2: "Apt. 4", city: "Portland", region: "OR", postal_code: "97212",
     reminders_via_email: true, reminders_via_text: true, receive_newsletter: true, volunteer_interest: true
   )
   User.create!(email: unverified_member.email, password: "password", member: unverified_member)

--- a/test/models/library_test.rb
+++ b/test/models/library_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class LibraryTest < ActiveSupport::TestCase
+  test "checks postal codes against pattern" do
+    library = build(:library, member_postal_code_pattern: "^902|19013")
+
+    assert library.allows_postal_code?("90215")
+    assert library.allows_postal_code?("19013")
+    refute library.allows_postal_code?("19011")
+    refute library.allows_postal_code?("90310")
+  end
+
+  test "allows any postal code when pattern is not set" do
+    library = build(:library, member_postal_code_pattern: "")
+
+    assert library.allows_postal_code?("90215")
+    assert library.allows_postal_code?("19013")
+    assert library.allows_postal_code?("19011")
+    assert library.allows_postal_code?("90310")
+  end
+end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -43,30 +43,25 @@ class MemberTest < ActiveSupport::TestCase
     assert_equal [member], Member.matching("(312) 123-4567")
   end
 
-  test "allows 606 postal codes" do
-    member = FactoryBot.build(:member)
+  test "checks postal codes against the library's pattern" do
+    library = build(:library, member_postal_code_pattern: "60707|60827|^606")
+    ActsAsTenant.with_tenant(library) do
+      member = build(:member)
 
-    assert member.valid?
-  end
+      member.postal_code = "60609"
+      assert member.valid?
 
-  test "allows 60707 postal code" do
-    member = FactoryBot.build(:member, postal_code: "60707")
+      member.postal_code = "60707"
+      assert member.valid?
 
-    assert member.valid?
-  end
+      member.postal_code = "60827"
+      assert member.valid?
 
-  test "allows 60827 postal code" do
-    member = FactoryBot.build(:member, postal_code: "60827")
-
-    assert member.valid?
-  end
-
-  test "rejects non-Chicago postal codes" do
-    member = FactoryBot.build(:member, postal_code: "90210")
-
-    assert member.invalid?
-    assert member.errors.messages.include?(:postal_code)
-    assert member.errors.messages[:postal_code].include?("must be in Chicago")
+      member.postal_code = "90210"
+      assert member.invalid?
+      assert member.errors.messages.include?(:postal_code)
+      assert member.errors.messages[:postal_code].include?("must be admissible in #{library.name}")
+    end
   end
 
   test "member without a user has a role 'member'" do


### PR DESCRIPTION
Allow each library to specify postal codes of territories that it caters to. A member must have a postal code that falls within the library's territories.